### PR TITLE
appimage: add missing dependency for PyQt5

### DIFF
--- a/appimage-2/Dockerfile
+++ b/appimage-2/Dockerfile
@@ -35,7 +35,17 @@ RUN ./install.sh \
 	    ;
 # For PyQt5.
 RUN ./install.sh \
+	    libasound2 \
+	    libegl1-mesa \
+	    libfontconfig1 \
 	    libgl1-mesa-glx \
+	    libnss3 \
+	    libxcomposite1 \
+	    libxcursor1 \
+	    libxi6 \
+	    libxrandr2 \
+	    libxss1 \
+	    libxtst6 \
 	    ;
 # Cleanup after ourselves...
 RUN rm install.sh

--- a/appimage-2/Dockerfile
+++ b/appimage-2/Dockerfile
@@ -1,18 +1,19 @@
 FROM ubuntu:trusty
-RUN apt-get update -y
+ENV DEBIAN_FRONTEND=noninteractive
+RUN printf '#!/bin/sh\nset -x; apt-get update -qqy && apt-get install -qqy "$@"' >install.sh && chmod +x install.sh
 # Build environment.
-RUN apt-get install -y \
+RUN ./install.sh \
 	    build-essential \
 	    ccache \
 	    wget \
 	    ;
 # For AppImage support.
-RUN apt-get install -y \
+RUN ./install.sh \
 	    fuse \
 	    libfuse2 \
 	    ;
 # For building Python 3.5.
-RUN apt-get install -y \
+RUN ./install.sh \
 	    libbz2-dev \
 	    libgdbm-dev \
 	    liblzma-dev \
@@ -23,16 +24,19 @@ RUN apt-get install -y \
 	    zlib1g-dev \
 	    ;
 # For building cython-hidapi.
-RUN apt-get install -y \
+RUN ./install.sh \
 	    libudev-dev \
 	    libusb-1.0-0-dev \
 	    ;
 # For building dbus-python.
-RUN apt-get install -y \
+RUN ./install.sh \
 	    libdbus-1-dev \
 	    libdbus-glib-1-dev \
 	    ;
 # For PyQt5.
-RUN apt-get install -y \
+RUN ./install.sh \
 	    libgl1-mesa-glx \
 	    ;
+# Cleanup after ourselves...
+RUN rm install.sh
+RUN apt-get clean

--- a/appimage-2/Dockerfile
+++ b/appimage-2/Dockerfile
@@ -11,10 +11,6 @@ RUN apt-get install -y \
 	    fuse \
 	    libfuse2 \
 	    ;
-# For utils.download.
-RUN apt-get install -y \
-	    python3-requests \
-	    ;
 # For building wmctrl.
 RUN apt-get install -y \
 	    libglib2.0-dev \

--- a/appimage-2/Dockerfile
+++ b/appimage-2/Dockerfile
@@ -42,3 +42,7 @@ RUN apt-get install -y \
 	    libdbus-1-dev \
 	    libdbus-glib-1-dev \
 	    ;
+# For PyQt5.
+RUN apt-get install -y \
+	    libgl1-mesa-glx \
+	    ;

--- a/appimage-2/Dockerfile
+++ b/appimage-2/Dockerfile
@@ -11,12 +11,6 @@ RUN apt-get install -y \
 	    fuse \
 	    libfuse2 \
 	    ;
-# For building wmctrl.
-RUN apt-get install -y \
-	    libglib2.0-dev \
-	    libx11-dev \
-	    libxmu-dev \
-	    ;
 # For building Python 3.5.
 RUN apt-get install -y \
 	    libbz2-dev \

--- a/archlinux-1/Dockerfile
+++ b/archlinux-1/Dockerfile
@@ -16,6 +16,7 @@ RUN pacman -S --needed --noconfirm \
 	    python-setuptools \
 	    python-setuptools-scm \
 	    python-six \
+	    python-wcwidth \
 	    python-xlib \
 	    wmctrl \
 	    ;

--- a/fedora-rawhide/Dockerfile
+++ b/fedora-rawhide/Dockerfile
@@ -15,5 +15,6 @@ RUN dnf -y install \
 	    python3-qt5 \
 	    python3-setuptools \
 	    python3-setuptools_scm \
+	    python3-wcwidth \
 	    python3-xlib \
 	    ;


### PR DESCRIPTION
So QT GUI plugins can be successfully loaded by `utils.check_requirements`.